### PR TITLE
Use base image now that 0.12 is default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary
+      - image: trussworks/circleci-docker-primary:c3cdcb24c00afc1ba635f8f6efd215f55aaf2079
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
With [this](https://github.com/trussworks/circleci-docker-primary/pull/83) having merged, 0.12 is now the default, so we don't need the tag. 